### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/data-raw/DATASET.R
+++ b/data-raw/DATASET.R
@@ -3,7 +3,9 @@ library(magrittr)
 
 rm(list = ls())
 
-conn <- poissqlite::ps_connect_sqlite("~/Poisson/Databases/curtis-qua-prod.sqlite")
+conn <- poissqlite::ps_connect_sqlite(
+  "~/Poisson/Databases/curtis-qua-prod.sqlite"
+)
 
 poissqlite::ps_load_tables(conn = conn, rename = stringr::str_to_lower)
 
@@ -97,7 +99,11 @@ efsite %<>%
     EFSite = factor(EFSite),
     Creek = str_replace(as.character(Creek), " Creek", ""),
     Creek = factor(Creek, levels = levels(creek$Creek)),
-    DominantSubstrate = fct_recode(DominantSubstrate, Boulder = "B", Cobble = "C")
+    DominantSubstrate = fct_recode(
+      DominantSubstrate,
+      Boulder = "B",
+      Cobble = "C"
+    )
   ) %>%
   select(EFSite, Creek, SiteLength, Elevation, DominantSubstrate, geometry)
 
@@ -110,9 +116,13 @@ efspecies %<>%
 usethis::use_data(efspecies, overwrite = TRUE)
 
 efvisit %<>%
-  select(EFSite,
+  select(
+    EFSite,
     DateEFVisit = DateTimeEFVisitStart,
-    Conductivity, EFSecPass1, EFSecPass2, EFSecPass3
+    Conductivity,
+    EFSecPass1,
+    EFSecPass2,
+    EFSecPass3
   ) %>%
   mutate(
     EFSite = factor(EFSite, levels = levels(efsite$EFSite)),
@@ -127,7 +137,15 @@ effish %<>%
     DateEFVisit = dttr2::dtt_date(DateEFVisit),
     BodyWeight = as.double(BodyWeight)
   ) %>%
-  select(EFSite, DateEFVisit, EFPass, FishNumber, Species, ForkLength, BodyWeight)
+  select(
+    EFSite,
+    DateEFVisit,
+    EFPass,
+    FishNumber,
+    Species,
+    ForkLength,
+    BodyWeight
+  )
 
 usethis::use_data(effish, overwrite = TRUE)
 

--- a/tests/testthat/test-benthiccount.R
+++ b/tests/testthat/test-benthiccount.R
@@ -13,6 +13,10 @@ test_that("check_data", {
     nrow = TRUE,
     key = c("BioSite", "DateBenthicSample", "Order", "Family")
   ))
-  chk::chk_join(benthiccount, benthicsample, by = c("BioSite", "DateBenthicSample"))
+  chk::chk_join(
+    benthiccount,
+    benthicsample,
+    by = c("BioSite", "DateBenthicSample")
+  )
   chk::chk_join(benthiccount, taxon, by = c("Family", "Order"))
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)